### PR TITLE
Use sizeof(uin32_t) when configuring HCI command packet

### DIFF
--- a/uim.c
+++ b/uim.c
@@ -359,7 +359,7 @@ int st_uart_config(unsigned char install)
 			/* Forming the packet for Change speed command */
 			cmd.uart_prefix = HCI_COMMAND_PKT;
 			cmd.hci_hdr.opcode = HCI_HDR_OPCODE;
-			cmd.hci_hdr.plen = sizeof(unsigned long);
+			cmd.hci_hdr.plen = sizeof(uint32_t);
 			cmd.speed = cust_baud_rate;
 
 			/* Writing the change speed command to the UART


### PR DESCRIPTION
This patch configures the uim-sysfs daemon to use the sizeof(uint32_t) statement when configuring the HCI command packet, specifically the packet payload length field.  The bit width of 'unsigned long' can differ between 32-bit and 64-bit platforms (specifically: 4 bytes for 32-bit, 8 bytes for 64-bit) and result in an incorrect payload length in the HCI command packet header.  This causes the Bluetooth chip to not respond to the command, resulting in the chip not being configured at all and ultimately non-functional Bluetooth.

So, the lesson here is to ALWAYS USE EXPLICIT TYPE SIZES if the bit width of the type matters, as it does here.